### PR TITLE
Use placeholder image if item.image is null

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
       resource :follow, only: %i[create destroy]
     end
 
-    resources :items, param: :slug, except: %i[edit new] do
+    resources :items, param: :slug,
+      constraints: { slug: /[A-Za-z0-9_.]+./ },
+      except: %i[edit new] do
       resource :favorite, only: %i[create destroy]
       resources :comments, only: %i[create index destroy]
       get :feed, on: :collection

--- a/frontend/src/agent.js
+++ b/frontend/src/agent.js
@@ -48,20 +48,48 @@ const Tags = {
   getAll: () => requests.get("/tags"),
 };
 
+const applyPlaceholderImg = (item) => {
+  if (!item.image) {
+    item.image = "/placeholder.png";
+  }
+  return item;
+};
+
+const applyItemDefaults = (data) => {
+  console.log(data);
+  if (data.items) {
+    data.items = data.items.map((item) => {
+      return applyPlaceholderImg(item);
+    });
+  }
+  if (data.item) {
+    data.item = applyPlaceholderImg(data.item);
+  }
+  return data;
+};
+
 const limit = (count, p) => `limit=${count}&offset=${p ? p * count : 0}`;
 const omitSlug = (item) => Object.assign({}, item, { slug: undefined });
 const Items = {
-  all: (page) => requests.get(`/items?${limit(1000, page)}`),
+  all: (page) =>
+    requests.get(`/items?${limit(1000, page)}`).then(applyItemDefaults),
   bySeller: (seller, page) =>
-    requests.get(`/items?seller=${encode(seller)}&${limit(500, page)}`),
+    requests
+      .get(`/items?seller=${encode(seller)}&${limit(500, page)}`)
+      .then(applyItemDefaults),
   byTag: (tag, page) =>
-    requests.get(`/items?tag=${encode(tag)}&${limit(1000, page)}`),
+    requests
+      .get(`/items?tag=${encode(tag)}&${limit(1000, page)}`)
+      .then(applyItemDefaults),
   del: (slug) => requests.del(`/items/${slug}`),
   favorite: (slug) => requests.post(`/items/${slug}/favorite`),
   favoritedBy: (seller, page) =>
-    requests.get(`/items?favorited=${encode(seller)}&${limit(500, page)}`),
-  feed: () => requests.get("/items/feed?limit=10&offset=0"),
-  get: (slug) => requests.get(`/items/${slug}`),
+    requests
+      .get(`/items?favorited=${encode(seller)}&${limit(500, page)}`)
+      .then(applyItemDefaults),
+  feed: () =>
+    requests.get("/items/feed?limit=10&offset=0").then(applyItemDefaults),
+  get: (slug) => requests.get(`/items/${slug}`).then(applyItemDefaults),
   unfavorite: (slug) => requests.del(`/items/${slug}/favorite`),
   update: (item) =>
     requests.put(`/items/${item.slug}`, { item: omitSlug(item) }),

--- a/frontend/src/reducers/item.js
+++ b/frontend/src/reducers/item.js
@@ -8,6 +8,15 @@ import {
 const reducer = (state = {}, action) => {
   switch (action.type) {
     case ITEM_PAGE_LOADED:
+      if (action.error) {
+        console.log(action.payload);
+        return state;
+      }
+
+      if (!action.payload[0].item.image) {
+        action.payload[0].item.image = "placeholder.png";
+      }
+
       return {
         ...state,
         item: action.payload[0].item,


### PR DESCRIPTION
This replaces the image in the frontend after receiving data.

The backend router is fixed to handle slugs correctly.

Fixes: #4

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New feature
- [ ] A documentation update
- [ ] Refactoring

# How Has This Been Tested?

Manually verified

Item list:

![1645378750](https://user-images.githubusercontent.com/436846/154856273-6bd09df0-6884-4c37-ace6-a3c0edda40a3.png)

Item view:

![1645378740](https://user-images.githubusercontent.com/436846/154856281-11257697-bbb9-4a98-ad2b-d0a8b08c31bd.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I added the relevant people as reviewers to my PR
